### PR TITLE
feat: Update user registration to send a password setup link with token

### DIFF
--- a/app/Events/UserRegisteredEvent.php
+++ b/app/Events/UserRegisteredEvent.php
@@ -10,12 +10,12 @@ class UserRegisteredEvent
     use Dispatchable, SerializesModels;
 
     public $user;
-    public $password; // Add the password
+    public $token; // Add the token
 
 
-    public function __construct(User $user, string $password)
+    public function __construct(User $user, string $token)
     {
         $this->user = $user;
-        $this->password = $password;
+        $this->token = $token;
     }
 }

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -15,6 +15,10 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
+use App\Http\Requests\User\PasswordSetupRequest;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 
 class AuthController extends Controller
 {
@@ -25,16 +29,39 @@ class AuthController extends Controller
         $this->authorize('register', Auth::user());
 
         $data = $request->validated();
-        $user = User::create($data);
-        event(new UserRegisteredEvent($user, $data['password']));
+        $data['password'] = Hash::make(str()->random(10));// Temporary password
 
+        $user = User::create($data);
         $token = $user->createToken('auth_token')->plainTextToken;
+
+        // This should create the token in your `password_reset_tokens` table
+        $passwored_token = Password::createToken($user);
+        // Trigger event to send a url to the user to setup their password
+        event(new UserRegisteredEvent($user, $passwored_token));
+
 
         return response()->json([
             'data' => UserResource::make($user),
             'access_token' => $token,
             'token_type' => 'Bearer',
         ], 201);
+    }
+
+    // Password Setup for first time through email
+    public function passwordSetup(PasswordSetupRequest $request)
+    {
+        $status = Password::reset(
+            $request->only('email', 'password', 'password_confirmation', 'token'),
+            function (User $user, string $password) {
+                $user->forceFill([
+                    'password' => $password
+                ])->save();
+            }
+        );
+
+        return $status === Password::PASSWORD_RESET
+            ? response()->json(['message' => 'Password has been setup successfully.'], 200)
+            : response()->json(['message' => 'Invalid token.'], 400);
     }
 
     public function updatePassword(UpdatePasswordRequest $request)

--- a/app/Http/Requests/User/PasswordSetupRequest.php
+++ b/app/Http/Requests/User/PasswordSetupRequest.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Http\Requests\User;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PasswordSetupRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;  // You can adjust this based on your authorization needs
+    }
+
+    public function rules()
+    {
+        return [
+            'token' => 'required',
+            'password' => 'required|string|confirmed|min:8',
+            'email' => 'required|email',
+        ];
+    }
+}

--- a/app/Http/Requests/User/RegisterUserRequest.php
+++ b/app/Http/Requests/User/RegisterUserRequest.php
@@ -29,7 +29,7 @@ class RegisterUserRequest extends FormRequest
         return [
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|max:255|unique:users',
-            'password' => 'required|string|min:8|confirmed',
+            // 'password' => 'required|string|min:8|confirmed',
             'role' => ['required', Rule::in(array_keys(User::ROLES))],
         ];
     }

--- a/app/Listeners/UserRegisteredListener.php
+++ b/app/Listeners/UserRegisteredListener.php
@@ -14,7 +14,7 @@ class UserRegisteredListener implements ShouldQueue
     public function handle(UserRegisteredEvent $event)
     {
         // Your email sending logic here
-        Mail::to($event->user->email)->send(new UserRegisteredMail($event->user, $event->password));
+        Mail::to($event->user->email)->send(new UserRegisteredMail($event->user, $event->token));
 
     }
 

--- a/app/Mail/UserRegisteredMail.php
+++ b/app/Mail/UserRegisteredMail.php
@@ -11,17 +11,20 @@ class UserRegisteredMail extends Mailable
     use Queueable, SerializesModels;
 
     public $user;
-    public $password;
+    public $token;
 
-    public function __construct($user, $password)
+    public function __construct($user, $token)
     {
         $this->user = $user;
-        $this->password = $password;
+        $this->token = $token;
     }
 
     public function build()
     {
+        $url = config('app.url') . '/register?token=' . $this->token;
+
         return $this->subject('Welcome to MoMo Education Platform!')
-            ->view('emails.user_registered');
+            ->view('emails.user_registered')
+            ->with(['url' => $url]);
     }
 }

--- a/resources/views/emails/user_registered.blade.php
+++ b/resources/views/emails/user_registered.blade.php
@@ -8,10 +8,11 @@
 <body>
     <h1>Welcome, {{ $user->name }}!</h1>
     <p>Your account has been created successfully.</p>
-    <p>Here are your login details:</p>
-    <p>Email: {{ $user->email }}</p>
-    <p>Password: {{ $password }}</p>
-    <p>Please change your password after logging in for the first time.</p>
+    <p>Please click the following link to set your password:</p>
+
+    <a href="{{ $url }}">{{ $url }}</a>
+
+    <p>If you did not request this, no further action is required.</p>
 </body>
 
 </html>

--- a/routes/api/users.php
+++ b/routes/api/users.php
@@ -7,6 +7,12 @@ use App\Http\Controllers\Api\AuthController;
 Route::middleware('auth:sanctum')->group(function () {
     Route::post('register', [AuthController::class, 'register'])
         ->name('users.register');
+
+
+    Route::post('/users/password/reset', [AuthController::class, 'passwordSetup'])
+        ->name('password.update');
+
+
     Route::patch('/users/password', [AuthController::class, 'updatePassword'])
         ->name('users.password.update');
     Route::get('/users/roles', [UserController::class, 'getRoles'])

--- a/tests/Feature/User/UserFeatureTest.php
+++ b/tests/Feature/User/UserFeatureTest.php
@@ -242,15 +242,13 @@ class UserFeatureTest extends TestCase
         $response = $this->postJson('/api/register', [
             'name' => 'John Doe',
             'email' => 'john@example.com',
-            'password' => 'password123',
-            'password_confirmation' => 'password123',
+
             'role' => 'student',
         ]);
 
         // Assert that the UserRegistered event was dispatched
         Event::assertDispatched(UserRegisteredEvent::class, function ($event) {
-            return $event->user->email === 'john@example.com'
-                && $event->password === 'password123';
+            return $event->user->email === 'john@example.com';
         });
     }
 


### PR DESCRIPTION
- Changed registration process to generate a unique token.
- Sent an email with a link for users to set their password.
- Added token verification and password setup functionality.